### PR TITLE
Updated Yantras menu item in navbar

### DIFF
--- a/ACMWOC/kaaryavarta.html
+++ b/ACMWOC/kaaryavarta.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">

--- a/ACMWOC/media_publicity.html
+++ b/ACMWOC/media_publicity.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">

--- a/ACMWOC/saahitya.html
+++ b/ACMWOC/saahitya.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">

--- a/ACMWOC/sanganitra.html
+++ b/ACMWOC/sanganitra.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">

--- a/ACMWOC/vidyut.html
+++ b/ACMWOC/vidyut.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">

--- a/ACMWOC/yantrika.html
+++ b/ACMWOC/yantrika.html
@@ -33,8 +33,8 @@
                 </button>
                 <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
                     <ul class="nav navbar-nav menu_nav ml-auto">
-                        <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item submenu dropdown">
+                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                        <li class="nav-item active submenu dropdown">
                             <a href="#yantras" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button"
                                 aria-haspopup="true" aria-expanded="false">Yantras</a>
                             <ul class="dropdown-menu">


### PR DESCRIPTION
The active class had been applied to the 'HOME' list item on all the pages corresponding to the Yantras sub-menu in navbar. The active class has been removed from there. The active class has been applied to Yantras list item on all the pages corresponding to Yantras sub-menu in navbar.